### PR TITLE
support get exit reason by reqeust.get_event_data

### DIFF
--- a/dueros/Request.py
+++ b/dueros/Request.py
@@ -118,7 +118,7 @@ class Request(Base):
         :return:
         """
 
-        if self.request_type == 'IntentRequest' or self.is_session_ended_request() or self.is_launch_request():
+        if self.request_type == 'IntentRequest' or self.is_launch_request():
             return
         else:
             return self.data['request']


### PR DESCRIPTION
你好，我是dueros的开发者，同时也是一名内部rd。最近在通过庆良找到了这个python的sdk，其实python是非常适合用来做skill开发，可惜官方并没有提供python版本，这对整个dueros开发者生态来说是一个巨大的缺陷。

很高兴看到你在为这个开源项目持续的贡献和开发，作为一个使用者，我非常期待这个sdk可以越做越好，能够有越来越多的人来使用它。为此我希望能参与到这个项目的开发中来，和你一起完善这个sdk。

本次提交的修改目的如下：
在sessionendedrequest请求发送到bot的之后，有时会有希望获得退出原因（包括：用户主动退出 & exceed_max_reprompt）的需要，本次修改主要是为了支持这一功能。

另外，是否有考虑增加对windows下的支持呢？